### PR TITLE
The Java JDK is now detected as a JRE runtime

### DIFF
--- a/jredetector_win.cpp
+++ b/jredetector_win.cpp
@@ -10,7 +10,12 @@
 #include "log.h"
 #include "platform.h"
 
-const CString JRE_KEY = "SOFTWARE\\JavaSoft\\Java Runtime Environment\\1.8";
+const int JRE_KEY_COUNT = 2;
+const CString JRE_KEYS[2] =
+{
+	"SOFTWARE\\JavaSoft\\Java Runtime Environment\\1.8",
+	"SOFTWARE\\JavaSoft\\Java Development Kit\\1.8"
+};
 const CString JAVA_HOME_KEY = "JavaHome";
 
 bool JreDetector::isValidJre(string javaHome) {
@@ -30,9 +35,15 @@ bool JreDetector::isValidJre(string javaHome) {
 string JreDetector::detectSystemJre() {
 	CRegKey regKey;
 	LSTATUS status;
-	if ((status = regKey.Open(HKEY_LOCAL_MACHINE, JRE_KEY, KEY_READ)) != ERROR_SUCCESS) {
-		log() << "Could not find registry key " << JRE_KEY.GetString() << " Status: " << status << "\n";
-		return "";
+
+	for (int key = 0; key < JRE_KEY_COUNT; key++) {
+		CString jreKey = JRE_KEYS[key];
+		if ((status = regKey.Open(HKEY_LOCAL_MACHINE, jreKey, KEY_READ)) != ERROR_SUCCESS) {
+			log() << "Could not find registry key " << jreKey.GetString() << " Status: " << status << "\n";
+			if (key == JRE_KEY_COUNT - 1) {
+				return "";
+			}
+		}
 	}
 
 	char javaHome[MAX_PATH + 1];


### PR DESCRIPTION
#### Description:
The registry key for the Java Development Kit (JDK) is now searched in addition to the JRE key when searching for an existing Java installation on Windows. Further information can be found in https://github.com/MovingBlocks/Terasology/issues/3782#issuecomment-562317402.

#### Testing:
 - Clone this pull request and compile the code
##### Testing for JDK-only:
 - Copy and run the produced executables on a machine with the JDK installed but not the JRE
##### Testing for JRE-only (previous behaviour):
 - Copy and run the produced executables on a machine with the JRE installed but not the JDK
##### Testing for systems with both JDK and JRE (untested):
 - Copy and run the produced executables on a machine with both the JRE and the JDK installed
#### Expected Result:
 - The code should now detect the Java installation (it may produce an error relating to a missing Terasology installation)
#### Notes:
This may fix https://github.com/MovingBlocks/Terasology/issues/3782.
I have only tested this on my own device so far, where it fixes the issue. This will need testing on more varied configurations before it can be considered a stable change.

#### Known Issues:
Sometimes calls to `CRegKey::Open` cause a crash when called more than once on the same key. I can no longer re-produce the crash though.